### PR TITLE
Fix the location that the extensions shared library is installed at

### DIFF
--- a/ext/stack_frames/extconf.rb
+++ b/ext/stack_frames/extconf.rb
@@ -1,3 +1,3 @@
 require 'mkmf'
 $CFLAGS << ' -Wall -Werror -Wextra -Wno-unused-parameter -Wno-missing-field-initializers'
-create_makefile("stack_frames")
+create_makefile("stack_frames/stack_frames")


### PR DESCRIPTION
## Problem

The extension was getting installed directly under the load path directory (e.g. `stack_frames.bundle` was directly beside `stack_frames.rb`), rather than under the `stack_frames` directory.  This was resulting in a `cannot load such file -- stack_frames/stack_frames (LoadError)` error on `require 'stack_frames/stack_frames'` in `lib/stack_frames.rb`.

## Solution

It looks like the target was being specified in the extconf.rb as the first argument to `create_makefile`.  So I just needed to add the directory there, so that it works properly when it is installed.

Any ideas of how to test this in development?  It would be nice if rake-compiler installed the extension using what is in extconf.rb, since it should be the source of truth on this.  Otherwise, I can look into that later to see if there is something we can do to test this properly.  At least it won't really need to be changed once it is working.