### PR TITLE
Add StackFrames::Buffer#find and add tests for #each and #[]

### DIFF
--- a/ext/stack_frames/buffer.c
+++ b/ext/stack_frames/buffer.c
@@ -110,6 +110,19 @@ static VALUE buffer_each(VALUE self) {
     return Qnil;
 }
 
+static VALUE buffer_find(VALUE self) {
+    buffer_t *buffer;
+
+    TypedData_Get_Struct(self, buffer_t, &buffer_data_type, buffer);
+    for (int i = 0; i < buffer->length; i++) {
+        VALUE frame = buffer->frames[i];
+        if (RTEST(rb_yield(frame))) {
+            return frame;
+        }
+    }
+    return Qnil;
+}
+
 VALUE stack_buffer_profile_frame(VALUE buffer_obj, int index) {
     buffer_t *buffer;
     TypedData_Get_Struct(buffer_obj, buffer_t, &buffer_data_type, buffer);
@@ -129,6 +142,7 @@ void stack_buffer_define(VALUE mStackFrames) {
     rb_define_method(cBuffer, "length", buffer_length, 0);
     rb_define_method(cBuffer, "capacity", buffer_capacity, 0);
     rb_define_method(cBuffer, "capture", buffer_capture, 0);
-    rb_define_method(cBuffer, "each", buffer_each, 0);
     rb_define_method(cBuffer, "[]", buffer_aref, 1);
+    rb_define_method(cBuffer, "each", buffer_each, 0);
+    rb_define_method(cBuffer, "find", buffer_find, 0);
 }

--- a/test/stack_frames/buffer_test.rb
+++ b/test/stack_frames/buffer_test.rb
@@ -83,6 +83,21 @@ class StackFrames::BufferTest < Minitest::Test
     assert_equal(buffer.length, i)
   end
 
+  def test_find
+    buffer = StackFrames::Buffer.new(10)
+    frame2 do
+      frame1 do
+        buffer.capture
+      end
+    end
+    frame = buffer.find { |frame| frame.method_name == "frame2" }
+    assert_equal(method(:frame2).source_location[1] + 1, frame.lineno)
+
+    assert_same(buffer[0], buffer.find { |frame| true })
+
+    assert_nil(buffer.find { |frame| false })
+  end
+
   private
 
   def frame1


### PR DESCRIPTION
Using https://github.com/Shopify/stack_frames/pull/3 as the base, mostly to avoid having to resolve merge conflicts after it gets merged.

## Problem

In the case where we are searching the stack for a frame matching some condition, it would be both more convenient and more performance to have a `StackFrames::Buffer#find`.

Note that using a `break` in a `StackFrames::Buffer#each` block actually causes an object allocation.  Doing `StackFrames::Buffer#[]` in a loop could work-around that, but that seems even less convenient for this common use case.

## Solution

Add `StackFrames::Buffer#find` which works like `Array#find` when passing a block.