### PR TITLE
Prepare for open sourcing

### DIFF
--- a/.github/probots.yml
+++ b/.github/probots.yml
@@ -1,0 +1,3 @@
+# .github/probots.yml
+enabled:
+  - cla

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Shopify
+Copyright (c) 2019-present, Shopify Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This repo was created with the intention of open sourcing.  I had just not made it open source at first, since I wanted to make sure it was used and worked in Shopify core, which is the case now.

One use case I have in mind for this library is to use it as an optimization for https://github.com/Shopify/deprecation_toolkit, when it is using a caller based shitlist.

Looks like this repo already has a travis configuration file for testing that I could enable once the repo is public.  However, it was missing the CLA bot configuration, which this PR adds.