### PR TITLE
Avoid turning compiler warnings into errors outside of development

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,8 @@ require "bundler/gem_tasks"
 require "rake/testtask"
 require 'rake/extensiontask'
 
+ENV['STACK_FRAMES_DEV'] = '1'
+
 Rake::ExtensionTask.new("stack_frames") do |ext|
   ext.lib_dir = 'lib/stack_frames'
 end

--- a/ext/stack_frames/extconf.rb
+++ b/ext/stack_frames/extconf.rb
@@ -1,3 +1,4 @@
 require 'mkmf'
-$CFLAGS << ' -Wall -Werror -Wextra -Wno-unused-parameter -Wno-missing-field-initializers'
+$CFLAGS << ' -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers'
+$CFLAGS << ' -Werror' if ENV['STACK_FRAMES_DEV']
 create_makefile("stack_frames/stack_frames")

--- a/stack_frames.gemspec
+++ b/stack_frames.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency 'rake-compiler', '~> 1.0'
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
## Problem

Turning compiler warnings into errors means that building the native extension can be brittle on installation, since it can result in issues with other compilers, compiler versions or other relevant changes to the environment.

## Solution

Only turn compiler warnings into errors for CI and development, where developers will have more context to fix the problem.