### PR TITLE
Use rb_global_variable to avoid problems with GC.compact

### DIFF
--- a/ext/stack_frames/frame.c
+++ b/ext/stack_frames/frame.c
@@ -72,6 +72,8 @@ DEFINE_FRAME_ACCESSOR(qualified_method_name)
 
 void stack_frame_define(VALUE mStackFrames) {
     cFrame = rb_define_class_under(mStackFrames, "Frame", rb_cObject);
+    rb_global_variable(&cFrame);
+
     rb_define_alloc_func(cFrame, frame_allocate);
     rb_define_method(cFrame, "lineno", frame_lineno, 0);
     rb_define_method(cFrame, "path", frame_path, 0);

--- a/ext/stack_frames/stack_frames.c
+++ b/ext/stack_frames/stack_frames.c
@@ -2,10 +2,8 @@
 #include "frame.h"
 #include "buffer.h"
 
-VALUE mStackFrames;
-
 void Init_stack_frames() {
-    mStackFrames = rb_define_module("StackFrames");
+    VALUE mStackFrames = rb_define_module("StackFrames");
     stack_buffer_define(mStackFrames);
     stack_frame_define(mStackFrames);
 }


### PR DESCRIPTION
## Problem

GC.compact can move objects to new addresses so we need to use `rb_global_variable` for any global variables in C extensions.  However, we were completely missing that in this gem.

## Solution

I only saw two global C variables:
* I used `rb_global_variable` with `VALUE cFrame`
* `VALUE mStackFrames` didn't need to be global, so I made it local

I tried reproducing the problem by using `GC.compact` in the test suite [as was done in liquid-c](https://github.com/Shopify/liquid-c/blob/c15309ea998cc794fe4cba03559d4eb3b15b0533/test/liquid_test.rb#L13-L20) but wasn't able to reproduce the crash with or without the change.  Any other ideas on how to test this?