### PR TITLE
Set capcity incrementally while constructing buffer

### DIFF
--- a/ext/stack_frames/buffer.c
+++ b/ext/stack_frames/buffer.c
@@ -58,11 +58,12 @@ static VALUE buffer_initialize(VALUE self, VALUE size) {
     TypedData_Get_Struct(self, buffer_t, &buffer_data_type, buffer);
     buffer->profile_frames = ALLOC_N(VALUE, capacity);
     buffer->lines = ALLOC_N(int, capacity);
-    buffer->capacity = capacity;
     buffer->frames = ALLOC_N(VALUE, capacity);
 
+    buffer->capacity = 0;
     for (int i = 0; i < capacity; i++) {
         buffer->frames[i] = stack_frame_new(self, i);
+        buffer->capacity++;
     }
     return Qnil;
 }

--- a/test/stack_frames/buffer_test.rb
+++ b/test/stack_frames/buffer_test.rb
@@ -98,6 +98,13 @@ class StackFrames::BufferTest < Minitest::Test
     assert_nil(buffer.find { |frame| false })
   end
 
+  def test_gc_stress
+    GC.stress = true
+    StackFrames::Buffer.new(10)
+  ensure
+    GC.stress = false
+  end
+
   private
 
   def frame1


### PR DESCRIPTION
Allocating frames can trigger GC and we only want to be marking
values that point to objects.

Should fix #11. 