### PR TITLE
Raise if a stack frame reference has been invalidated from a further capture

### DIFF
--- a/ext/stack_frames/buffer.c
+++ b/ext/stack_frames/buffer.c
@@ -124,15 +124,22 @@ static VALUE buffer_find(VALUE self) {
     return Qnil;
 }
 
+static void raise_frame_reference_error()
+{
+    rb_raise(rb_eRuntimeError, "Stack frame is no longer valid, its buffer was re-used for another capture");
+}
+
 VALUE stack_buffer_profile_frame(VALUE buffer_obj, int index) {
     buffer_t *buffer;
     TypedData_Get_Struct(buffer_obj, buffer_t, &buffer_data_type, buffer);
+    if (index >= buffer->length) raise_frame_reference_error();
     return buffer->profile_frames[index];
 }
 
 int stack_buffer_frame_lineno(VALUE buffer_obj, int index) {
     buffer_t *buffer;
     TypedData_Get_Struct(buffer_obj, buffer_t, &buffer_data_type, buffer);
+    if (index >= buffer->length) raise_frame_reference_error();
     return buffer->lines[index];
 }
 

--- a/ext/stack_frames/extconf.rb
+++ b/ext/stack_frames/extconf.rb
@@ -1,4 +1,4 @@
 require 'mkmf'
-$CFLAGS << ' -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers'
+$CFLAGS << ' -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wno-missing-noreturn'
 $CFLAGS << ' -Werror' if ENV['STACK_FRAMES_DEV']
 create_makefile("stack_frames/stack_frames")

--- a/test/stack_frames/buffer_test.rb
+++ b/test/stack_frames/buffer_test.rb
@@ -115,6 +115,20 @@ class StackFrames::BufferTest < Minitest::Test
     GC.stress = false
   end
 
+  def test_frame_invalidated_from_recapture
+    buffer = StackFrames::Buffer.new(100)
+    frame1 do
+      buffer.capture
+    end
+    last_index = buffer.length - 1
+    frame = buffer[last_index]
+    buffer.capture
+    exc = assert_raises(RuntimeError) { frame.method_name }
+    assert_match(/\AStack frame is no longer valid,/, exc.message)
+    exc2 = assert_raises(RuntimeError) { frame.lineno }
+    assert_equal(exc.message, exc2.message)
+  end
+
   private
 
   def skipping_c_frames?


### PR DESCRIPTION
## Problem

When a `StackFrames::Buffer#capture` is called more than once, any StackFrames::Frame objects obtained from a previous capture with a frame number higher than the most recent capture's length will no longer reference a marked profile frame object.  This library needs to prevent using those no longer marked profile frame objects in the StackFrames::Buffer, but the provided regression test shows nothing gets raised when this happens without the corresponding fix.

## Solution

`StackFrames::Frame` just holds an index into the buffer, so I added a bounds check to catch this possible application bug so it can't produce undefined behaviour in this way.