### PR TITLE
Migrate to GitHub Actions and fix Ruby 3.0 and 3.1 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  rubies:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ ruby-head, '3.1', '3.0', '2.7', '2.6', '2.5' ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run test
+        run: bundle exec rake
+      - name: Install gem
+        run: bundle exec rake install
+  platforms:
+    strategy:
+      matrix:
+        os: [macos, windows]
+        ruby: ['2.5']
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run test
+        run: bundle exec rake
+      - name: Install gem
+        run: bundle exec rake install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
----
-sudo: false
-language: ruby
-cache: bundler
-rvm:
-  - 2.4.9 # minimum supported
-  - 2.7.0 # latest released
-before_install: gem install bundler -v 1.17.3

--- a/ext/stack_frames/extconf.rb
+++ b/ext/stack_frames/extconf.rb
@@ -1,4 +1,4 @@
 require 'mkmf'
-$CFLAGS << ' -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers'
-$CFLAGS << ' -Werror' if ENV['STACK_FRAMES_DEV']
+$CFLAGS << ' -Wall '
+$CFLAGS << ' -Werror ' if ENV['STACK_FRAMES_DEV']
 create_makefile("stack_frames/stack_frames")

--- a/ext/stack_frames/stack_frames.c
+++ b/ext/stack_frames/stack_frames.c
@@ -4,7 +4,7 @@
 
 VALUE mStackFrames;
 
-void Init_stack_frames() {
+void Init_stack_frames(void) {
     mStackFrames = rb_define_module("StackFrames");
     stack_buffer_define(mStackFrames);
     stack_frame_define(mStackFrames);

--- a/stack_frames.gemspec
+++ b/stack_frames.gemspec
@@ -25,8 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency 'rake-compiler', '~> 1.0'
-  spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_development_dependency "stackprof", "~> 0.2.13"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency 'rake-compiler'
+  spec.add_development_dependency "minitest"
 end

--- a/test/stack_frames/frame_test.rb
+++ b/test/stack_frames/frame_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class StackFrames::FrameTest < Minitest::Test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
+# frozen_string_literal: true
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "stack_frames"
-require 'stackprof'
 
 require "minitest/autorun"


### PR DESCRIPTION
There are a few subtle changes in 3.0 that I will point out in the diff comments.