### PR TITLE
Setup CI for 3.0 and 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,9 @@ jobs:
       matrix:
         ruby: [
           '2.6', # minimum supported
-          '2.7', # latest passing tests
+          '2.7',
+          '3.0',
+          '3.1',
         ]
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Ruby backtraces behave a bit differently in 3.0 and 3.1 because now the C methods frames are visible. So it's very valuable to test all intermediate versions and not just the oldest and newest supported.